### PR TITLE
Add Swagger/OpenAPI support for backend API

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -68,6 +68,13 @@
         </dependency>
 
         <!-- SpringBoot actuator -->
+
+        <!-- Swagger UI + OpenAPI для Spring Boot 3 -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/backend/src/main/java/vulnspa/config/SecurityConfig.java
+++ b/backend/src/main/java/vulnspa/config/SecurityConfig.java
@@ -116,6 +116,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/vip/**").authenticated()
                         .requestMatchers("/api/profile/**").authenticated()
                         .requestMatchers("/api/actuator/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         // всё остальное — открыто
                         .anyRequest().permitAll()
                 )

--- a/backend/src/main/java/vulnspa/config/SwaggerConfig.java
+++ b/backend/src/main/java/vulnspa/config/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package vulnspa.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Базовая конфигурация OpenAPI/Swagger UI.
+ */
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI vulnSpaOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Vuln SPA API")
+                        .description("Документация REST API для backend-модуля")
+                        .version("v1")
+                        .contact(new Contact().name("Vuln SPA Team"))
+                        .license(new License().name("MIT")));
+    }
+}


### PR DESCRIPTION
### Motivation
- Предоставить встроенную документацию REST API и Swagger UI для удобной разработки и тестирования API.
- Открыть публичный доступ к эндпоинтам спецификации и UI, чтобы они не блокировались конфигурацией Spring Security.

### Description
- Добавлена зависимость `org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0` в `backend/pom.xml` для генерации OpenAPI и Swagger UI.
- Обновлён `SecurityConfig` чтобы разрешить доступ к маршрутам `/v3/api-docs/**`, `/swagger-ui/**` и `/swagger-ui.html`.
- Добавлен новый класс `vulnspa.config.SwaggerConfig` с базовой метаинформацией OpenAPI (title, description, version, contact, license).

### Testing
- Попытка собрать модуль командой `mvn -f backend/pom.xml -DskipTests compile` была выполнена, но сборка не завершилась из‑за ошибки доступа к Maven Central (HTTP 403) при загрузке parent POM, поэтому интеграционная сборка не подтверждена.
- Unit/integration тесты в проекте не запускались в этом окружении из‑за указанной проблемы со скачиванием артефактов.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec0f0ded4832f882f4aaa82b9aa6c)